### PR TITLE
Add text decklist loader with API integration

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -10,8 +10,16 @@ from opt.search_ga import search_ga
 
 
 def load_cards(path: Path) -> List[Card]:
-    data = json.loads(path.read_text())
-    return [Card(**item) for item in data]
+    suffix = path.suffix.lower()
+    if suffix == ".json":
+        data = json.loads(path.read_text())
+        return [Card(**item) for item in data]
+    elif suffix == ".txt":
+        from decklist_txt_loader import load_deck as load_txt_deck
+
+        return load_txt_deck(path).cards
+    else:
+        raise ValueError(f"Unsupported deck format: {suffix}")
 
 
 def load_deck(path: Path) -> Deck:

--- a/decklist_txt_loader.py
+++ b/decklist_txt_loader.py
@@ -1,0 +1,69 @@
+import json
+from pathlib import Path
+from typing import List, Optional, Tuple
+import requests
+
+from engine.cards import Card
+from engine.deck import Deck
+
+API_URL = "https://api.magicthegathering.io/v1/cards"
+
+
+def _parse_line(line: str) -> Optional[tuple[int, str]]:
+    line = line.strip()
+    if not line or line.startswith("#"):
+        return None
+    parts = line.split(" ", 1)
+    if len(parts) != 2:
+        return None
+    qty_str, name = parts
+    try:
+        qty = int(qty_str)
+    except ValueError:
+        return None
+    return qty, name.strip()
+
+
+def _fetch_card(name: str) -> Optional[Card]:
+    try:
+        resp = requests.get(API_URL, params={"name": name}, timeout=10)
+        resp.raise_for_status()
+        data = resp.json().get("cards", [])
+        if not data:
+            print(f"Warning: card '{name}' not found")
+            return None
+        card_data = data[0]
+        power = card_data.get("power")
+        toughness = card_data.get("toughness")
+        pt: Optional[Tuple[int, int]] = None
+        try:
+            if power is not None and toughness is not None:
+                pt = (int(power), int(toughness))
+        except ValueError:
+            pt = None
+        return Card(
+            id=card_data.get("id", name),
+            name=card_data.get("name", name),
+            cmc=int(card_data.get("cmc", 0)),
+            types=card_data.get("types", []),
+            colors=card_data.get("colors", []),
+            pt=pt,
+            text_dsl=card_data.get("text", ""),
+        )
+    except Exception as exc:
+        print(f"Warning: failed to fetch card '{name}': {exc}")
+        return None
+
+
+def load_deck(path: Path) -> Deck:
+    cards: List[Card] = []
+    for line in path.read_text().splitlines():
+        parsed = _parse_line(line)
+        if not parsed:
+            continue
+        qty, name = parsed
+        card = _fetch_card(name)
+        if card is None:
+            continue
+        cards.extend([card] * qty)
+    return Deck(cards)

--- a/tests/test_decklist_txt_loader.py
+++ b/tests/test_decklist_txt_loader.py
@@ -1,0 +1,39 @@
+from types import SimpleNamespace
+from pathlib import Path
+
+from decklist_txt_loader import load_deck
+
+
+class DummyResponse:
+    def __init__(self, name: str):
+        self.name = name
+
+    def raise_for_status(self) -> None:  # pragma: no cover - simple stub
+        pass
+
+    def json(self) -> dict:
+        return {
+            "cards": [
+                {
+                    "id": f"id_{self.name}",
+                    "name": self.name,
+                    "cmc": 0,
+                    "types": ["Basic", "Land"],
+                    "colors": [],
+                    "text": "",
+                }
+            ]
+        }
+
+
+def fake_get(url: str, params: dict, timeout: int = 10) -> DummyResponse:
+    return DummyResponse(params["name"])
+
+
+def test_load_deck_from_txt(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr("decklist_txt_loader.requests.get", fake_get)
+    deck_file = tmp_path / "deck.txt"
+    deck_file.write_text("2 Forest\n")
+    deck = load_deck(deck_file)
+    assert len(deck.cards) == 2
+    assert all(card.name == "Forest" for card in deck.cards)


### PR DESCRIPTION
## Summary
- parse text decklists and fetch card details from MTG API
- allow CLI simulate command to read JSON or txt decklists
- cover text loader with unit test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab3327cd5c8331bc9b449c04b9297d