### PR TITLE
Add card fetching via Magic API and decklist loader

### DIFF
--- a/api/mgt_api.py
+++ b/api/mgt_api.py
@@ -1,0 +1,45 @@
+import requests
+from engine.cards import Card
+from typing import Optional, Tuple
+
+BASE_URL = "https://api.magicthegathering.io/v1/cards"
+
+
+def _parse_power_toughness(power: Optional[str], toughness: Optional[str]) -> Optional[Tuple[int, int]]:
+    try:
+        if power is None or toughness is None:
+            return None
+        return (int(power), int(toughness))
+    except (ValueError, TypeError):
+        return None
+
+
+def fetch_card_data(name: str) -> Card:
+    """Fetch card data from Magic: The Gathering API and return a Card instance.
+
+    Args:
+        name: The name of the card to search for.
+
+    Returns:
+        Card: The card data converted into a Card instance.
+
+    Raises:
+        ValueError: If the card is not found or the API response is invalid.
+    """
+    response = requests.get(BASE_URL, params={"name": name})
+    response.raise_for_status()
+    data = response.json()
+    cards = data.get("cards", [])
+    if not cards:
+        raise ValueError(f"Card '{name}' not found")
+    card_data = cards[0]
+    pt = _parse_power_toughness(card_data.get("power"), card_data.get("toughness"))
+    return Card(
+        id=card_data["id"],
+        name=card_data["name"],
+        cmc=int(card_data.get("cmc", 0)),
+        types=card_data.get("types", []),
+        colors=card_data.get("colors", []),
+        pt=pt,
+        text_dsl=card_data.get("text", ""),
+    )

--- a/store/__init__.py
+++ b/store/__init__.py
@@ -1,0 +1,1 @@
+from .decklist import load_decklist_txt

--- a/store/decklist.py
+++ b/store/decklist.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+from typing import List
+
+from engine.deck import Deck
+from engine.cards import Card
+from api.mgt_api import fetch_card_data
+
+
+def load_decklist_txt(path: Path) -> Deck:
+    """Load a deck list from a plaintext file using MTG API for card details."""
+    cards: List[Card] = []
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        try:
+            qty_str, name = line.split(" ", 1)
+            qty = int(qty_str)
+        except ValueError:
+            # skip malformed lines
+            continue
+        card = fetch_card_data(name)
+        cards.extend([card] * qty)
+    return Deck(cards)


### PR DESCRIPTION
## Summary
- add `fetch_card_data` utility hitting the Magic: the Gathering API
- support loading deck lists from plaintext files using live card data

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab333d4fd88331ae38050b71837acd