### PR TITLE
Document new CLI decklist and logging options

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,20 @@ Requires Python 3.10+.
 
 ## CLI
 
+The command-line interface accepts deck and horde lists in JSON or plain text
+formats. When a `.txt` deck list is used, card details are fetched from the
+Magic: The Gathering API.
+
 Simulate a deck against the basic Horde:
 
 ```bash
 python cli.py simulate --deck data/sample_deck.json --horde data/horde_basic.json --seeds 5
+```
+
+Simulate using a text deck list and log each game to a file:
+
+```bash
+python cli.py simulate --deck doctorWho_commander.txt --horde data/horde_basic.json --seeds 5 --logfile game.log
 ```
 
 Run the (toy) genetic algorithm optimizer:


### PR DESCRIPTION
## Summary
- explain how CLI accepts deck and horde lists in JSON or plain text, fetching card data via MTG API
- show example of using `--logfile` to save game logs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68ab387bdc3c833184b23af349821d2c