### PR TITLE
Traduz nomes e comenta recursos especiais para devs PHP

### DIFF
--- a/decklist_txt_loader.py
+++ b/decklist_txt_loader.py
@@ -3,79 +3,84 @@ from pathlib import Path
 from typing import List, Optional, Tuple
 from types import SimpleNamespace
 
-try:  # pragma: no cover - exercised via tests with monkeypatch
+try:  # pragma: no cover - utilizado em testes com monkeypatch
     import requests as _requests
-except Exception:  # requests may not be installed in minimal environments
+except Exception:  # ``requests`` pode não estar instalado em ambientes mínimos
     _requests = None
 
-# ``requests`` is exposed as a module-level object so that tests (and callers)
-# can monkeypatch ``requests.get`` even if the real library isn't available.
-def _missing_requests_get(*args, **kwargs):  # pragma: no cover - simple fallback
-    raise RuntimeError("requests library is required to fetch card data")
+# ``requests`` é exposto como um objeto de módulo para que testes e usuários
+# possam "monkeypatchar" ``requests.get`` mesmo se a biblioteca real não
+# estiver disponível.
+def _obter_requisicoes_ausente(*args, **kwargs):  # pragma: no cover - fallback simples
+    raise RuntimeError("a biblioteca requests é necessária para buscar dados de cartas")
 
-requests = _requests or SimpleNamespace(get=_missing_requests_get)
+# ``SimpleNamespace`` cria um objeto com atributos dinâmicos, recurso sem
+# equivalente direto em PHP.
+requests = _requests or SimpleNamespace(get=_obter_requisicoes_ausente)
 
 from engine.cards import Card
 from engine.deck import Deck
 
-API_URL = "https://api.magicthegathering.io/v1/cards"
+URL_API = "https://api.magicthegathering.io/v1/cards"
 
 
-def _parse_line(line: str) -> Optional[tuple[int, str]]:
-    line = line.strip()
-    if not line or line.startswith("#"):
+def _interpretar_linha(linha: str) -> Optional[tuple[int, str]]:
+    linha = linha.strip()
+    if not linha or linha.startswith("#"):
         return None
-    parts = line.split(" ", 1)
-    if len(parts) != 2:
+    partes = linha.split(" ", 1)
+    if len(partes) != 2:
         return None
-    qty_str, name = parts
+    qtd_str, nome = partes
     try:
-        qty = int(qty_str)
+        quantidade = int(qtd_str)
     except ValueError:
         return None
-    return qty, name.strip()
+    return quantidade, nome.strip()
 
 
-def _fetch_card(name: str) -> Optional[Card]:
+def _buscar_carta(nome: str) -> Optional[Card]:
     try:
-        resp = requests.get(API_URL, params={"name": name}, timeout=10)
-        resp.raise_for_status()
-        data = resp.json().get("cards", [])
-        if not data:
-            print(f"Warning: card '{name}' not found")
+        resposta = requests.get(URL_API, params={"name": nome}, timeout=10)
+        resposta.raise_for_status()  # mantemos o nome do método para compatibilidade com ``requests``
+        dados = resposta.json().get("cards", [])
+        if not dados:
+            print(f"Aviso: carta '{nome}' não encontrada")
             return None
-        card_data = data[0]
-        power = card_data.get("power")
-        toughness = card_data.get("toughness")
-        pt: Optional[Tuple[int, int]] = None
+        dados_carta = dados[0]
+        poder = dados_carta.get("power")
+        resistencia = dados_carta.get("toughness")
+        pontos: Optional[Tuple[int, int]] = None
         try:
-            if power is not None and toughness is not None:
-                pt = (int(power), int(toughness))
+            if poder is not None and resistencia is not None:
+                pontos = (int(poder), int(resistencia))
         except ValueError:
-            pt = None
+            pontos = None
         return Card(
-            id=card_data.get("id", name),
-            name=card_data.get("name", name),
-            cmc=int(card_data.get("cmc", 0)),
-            types=card_data.get("types", []),
-            colors=card_data.get("colors", []),
-            pt=pt,
-            text_dsl=card_data.get("text", ""),
+            id=dados_carta.get("id", nome),
+            name=dados_carta.get("name", nome),
+            cmc=int(dados_carta.get("cmc", 0)),
+            types=dados_carta.get("types", []),
+            colors=dados_carta.get("colors", []),
+            pt=pontos,
+            text_dsl=dados_carta.get("text", ""),
         )
     except Exception as exc:
-        print(f"Warning: failed to fetch card '{name}': {exc}")
+        print(f"Aviso: falha ao buscar carta '{nome}': {exc}")
         return None
 
 
-def load_deck(path: Path) -> Deck:
-    cards: List[Card] = []
-    for line in path.read_text().splitlines():
-        parsed = _parse_line(line)
-        if not parsed:
+def carregar_baralho(caminho: Path) -> Deck:
+    cartas: List[Card] = []  # anotação de tipo com genéricos; PHP não possui equivalente direto
+    # ``Path.read_text`` lê todo o conteúdo do arquivo; em PHP normalmente usaríamos ``file_get_contents``.
+    for linha in caminho.read_text().splitlines():
+        interpretado = _interpretar_linha(linha)
+        if not interpretado:
             continue
-        qty, name = parsed
-        card = _fetch_card(name)
-        if card is None:
+        quantidade, nome = interpretado
+        carta = _buscar_carta(nome)
+        if carta is None:
             continue
-        cards.extend([card] * qty)
-    return Deck(cards)
+        # Multiplicar uma lista por um inteiro replica seus elementos; em PHP seria necessário um laço.
+        cartas.extend([carta] * quantidade)
+    return Deck(cartas)

--- a/tests/test_decklist_txt_loader.py
+++ b/tests/test_decklist_txt_loader.py
@@ -1,22 +1,22 @@
 from types import SimpleNamespace
 from pathlib import Path
 
-from decklist_txt_loader import load_deck
+from decklist_txt_loader import carregar_baralho
 
 
-class DummyResponse:
-    def __init__(self, name: str):
-        self.name = name
+class RespostaDummy:
+    def __init__(self, nome: str):
+        self.nome = nome
 
-    def raise_for_status(self) -> None:  # pragma: no cover - simple stub
+    def raise_for_status(self) -> None:  # pragma: no cover - mantemos o nome para imitar ``requests``
         pass
 
     def json(self) -> dict:
         return {
             "cards": [
                 {
-                    "id": f"id_{self.name}",
-                    "name": self.name,
+                    "id": f"id_{self.nome}",
+                    "name": self.nome,
                     "cmc": 0,
                     "types": ["Basic", "Land"],
                     "colors": [],
@@ -26,14 +26,18 @@ class DummyResponse:
         }
 
 
-def fake_get(url: str, params: dict, timeout: int = 10) -> DummyResponse:
-    return DummyResponse(params["name"])
+def obter_falso(url: str, params: dict, timeout: int = 10) -> RespostaDummy:
+    # ``params`` é um dicionário; em PHP seria um array associativo.
+    return RespostaDummy(params["name"])
 
 
-def test_load_deck_from_txt(monkeypatch, tmp_path: Path) -> None:
-    monkeypatch.setattr("decklist_txt_loader.requests.get", fake_get)
-    deck_file = tmp_path / "deck.txt"
-    deck_file.write_text("2 Forest\n")
-    deck = load_deck(deck_file)
-    assert len(deck.cards) == 2
-    assert all(card.name == "Forest" for card in deck.cards)
+def teste_carregar_baralho_do_txt(monkeypatch, tmp_path: Path) -> None:
+    # ``monkeypatch`` é um recurso de testes do pytest para substituir atributos dinamicamente.
+    monkeypatch.setattr("decklist_txt_loader.requests.get", obter_falso)
+    # O operador ``/`` é sobrecarregado em ``Path`` para criar caminhos; PHP não possui essa sintaxe.
+    arquivo_baralho = tmp_path / "deck.txt"
+    arquivo_baralho.write_text("2 Forest\n")
+    baralho = carregar_baralho(arquivo_baralho)
+    assert len(baralho.cards) == 2
+    # Expressão geradora; em PHP seria necessário um laço ``foreach``.
+    assert all(carta.name == "Forest" for carta in baralho.cards)


### PR DESCRIPTION
## Summary
- renomeia funções e variáveis para o português
- adiciona comentários explicando recursos específicos do Python
- ajusta testes e CLI para usar a nova nomenclatura

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab3ccb352483318151da185e298b52